### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* `buildPluginWithGradle` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPluginWithGradle(platforms: ['linux'], jdkVersions: [8, 11])
+buildPluginWithGradle(platforms: ['linux'], jdkVersions: [8, 11], useContainerAgent: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(platforms: ['linux'], jdkVersions: [8, 11])
+/* `buildPluginWithGradle` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPluginWithGradle(platforms: ['linux'], jdkVersions: [8, 11])


### PR DESCRIPTION
The buildPlugin syntax is reserved for plugins using maven, and deprecated for plugins using gradle to build.
The change proposed updates the syntax to use the proper buildPluginWithGradle build step.